### PR TITLE
Fix CodeQL workflow to archive SARIF

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,12 +39,14 @@ jobs:
         queries: security-extended
 
     - name: Perform CodeQL Analysis
+      id: analyze
       uses: github/codeql-action/analyze@v3
       with:
         category: "/language:${{matrix.language}}"
+        output: ${{ runner.temp }}/codeql-${{ matrix.language }}
 
     - name: Upload SARIF Report as Artifact
       uses: actions/upload-artifact@v4
       with:
         name: codeql-report-${{ matrix.language }}
-        path: codeql-report-${{ matrix.language }}.sarif
+        path: ${{ steps.analyze.outputs.sarif-output }}


### PR DESCRIPTION
## Summary
- store the CodeQL SARIF results in a temporary directory
- upload the generated SARIF files as artifacts

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_6883f06c5e2483269539714a9ec63328